### PR TITLE
Cancel an update on specific stack  

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ Requires a stack name, `--file`, and `--parameters`.
 
 [![asciicast](https://asciinema.org/a/7e745ao7yz9v1kmubmf57vyfr.png)](https://asciinema.org/a/7e745ao7yz9v1kmubmf57vyfr)
 
+### cancel
+
+Cancels an update on the specified stack. The stack rolls back the update and reverts to the previous stack configuration.
+
+Requires a stack name, `--file`, and `--parameters`.
+
+
 ### delete
 
 Deletes an existing stack.

--- a/README.md
+++ b/README.md
@@ -72,8 +72,14 @@ Requires a stack name, `--file`, and `--parameters`.
 
 Cancels an update on the specified stack. The stack rolls back the update and reverts to the previous stack configuration.
 
-Requires a stack name, `--file`, and `--parameters`.
+Requires a stack name.
 
+Will prompt for confirmation.
+
+```
+Note
+  This will only work on a stack that are in the `UPDATE_IN_PROGRESS` state.
+```
 
 ### delete
 

--- a/src/commands/cancelUpdateStack.js
+++ b/src/commands/cancelUpdateStack.js
@@ -1,0 +1,52 @@
+import inquirer from 'inquirer'
+
+function cancelUpdateStack (cloudformation, argv, utils) {
+  const stackName = argv._[1]
+
+  inquirer.prompt([
+    {
+      type: 'confirm',
+      name: 'ok',
+      message: `Are you sure you want to cancel an update on ${stackName}?`
+    }
+  ], function (answers) {
+    if (!answers.ok) {
+      return process.exit()
+    }
+
+    const beforeCancelDate = new Date()
+
+    cloudformation.cancelUpdateStack({
+      StackName: stackName
+    }, function (err, response) {
+      if (err) {
+        throw new Error(err)
+      }
+
+      utils.pollEvents(stackName, 'Canceling...', [
+        [ 'LogicalResourceId', stackName ],
+        [ 'ResourceStatus', 'CANCEL_COMPLETE' ]
+      ], function (err) {
+        if (err) {
+          if (err.code !== 'ValidationError') {
+            throw new Error(err)
+          }
+          process.exit()
+        }
+
+        console.log(` ${stackName} update has been canceled...`.cyan)
+
+        process.exit()
+      }, {
+        startDate: beforeCancelDate,
+        ignoreMissing: true
+      })
+    })
+  })
+}
+
+export default {
+  name: 'cancel',
+  description: 'Cancels an update on the specified stack',
+  fn: cancelUpdateStack
+}


### PR DESCRIPTION
add a cancel update stack, this is useful when you're updating a stack and want to cancel and revert to previous version before it completes.

I reused the code in `deleteStack.js`, so nothing much is changed.